### PR TITLE
fix: misleading example title

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -36,7 +36,7 @@ Simply add the components directory or copy paste the required components.
 
 
 
-|               Dark mode               |               Light mode               |
+|               Light mode               |               Dark mode               |
 | :-----------------------------------: | :------------------------------------: |
 | ![](https://raw.githubusercontent.com/Mobilecn-UI/nativecn-ui/main/assets/examples/example-light.png) | ![](https://raw.githubusercontent.com/Mobilecn-UI/nativecn-ui/main/assets/examples/example-dark.png) |
 


### PR DESCRIPTION
### Why this PR?
- This PR fixes the misleading example title in the Introduction Docs

Expected:

![image](https://github.com/Mobilecn-UI/nativecn-ui/assets/8493007/d320a5b6-110b-4c93-8b7a-7e2ee93e25ab)

Current:

![image](https://github.com/Mobilecn-UI/nativecn-ui/assets/8493007/aa0e4571-ca63-4a9e-8cb9-b35a800d7772)
