### PR TITLE
Light mode

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -6,7 +6,7 @@
   },
   "favicon": "/favicon.png",
   "colors": {
-    "primary": "#ffffff",
+    "primary": "#40dcfc",
     "light": "#40dcfc",
     "dark": "#0D001D",
     "background": {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -13,7 +13,7 @@
       "dark": "#090014"
     },
     "anchors": {
-      "from": "#ffffff",
+      "from": "#2564eb",
       "to": "#40dcfc"
     }
   },


### PR DESCRIPTION
There is an issue in light mode where the selected tab name becomes
white hence the text will not be visible.
Have changed the primary color, so now the text is visible.

![image](https://github.com/user-attachments/assets/002497df-9926-4ff5-b057-67af7cf48ca1)
